### PR TITLE
refactor: adopt renamed action names

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ```yaml
       - name: CDK Build and Deploy
-        uses: p6m7g8-actions/cdk-deploy@main
+        uses: p6m7g8-actions/p6-cdk-deploy@main
         with:
           aws_region: ${{ secrets.CDK_DEPLOY_REGION }}
           aws_role: ${{ secrets.AWS_ROLE }}

--- a/action.yml
+++ b/action.yml
@@ -26,31 +26,31 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: p6m7g8-actions/checkout@main
+      uses: p6m7g8-actions/gh-repo-checkout@main
     - name: Checkout code p6common
-      uses: p6m7g8-actions/checkout@main
+      uses: p6m7g8-actions/gh-repo-checkout@main
       with:
         repository: "p6m7g8-dotfiles/p6common"
         path: ".deps/p6common"
     - name: Checkout code p6aws
-      uses: p6m7g8-actions/checkout@main
+      uses: p6m7g8-actions/gh-repo-checkout@main
       with:
         repository: "p6m7g8-dotfiles/p6aws"
         path: ".deps/p6aws"
     - name: Checkout code p6awscdk
-      uses: p6m7g8-actions/checkout@main
+      uses: p6m7g8-actions/gh-repo-checkout@main
       with:
         repository: "p6m7g8-dotfiles/p6awscdk"
         path: ".deps/p6awscdk"
     - name: Checkout code p6-cirrus
-      uses: p6m7g8-actions/checkout@main
+      uses: p6m7g8-actions/gh-repo-checkout@main
       with:
         repository: "p6m7g8/p6-cirrus"
         path: ".deps/p6-cirrus"
     - name: Node
-      uses: p6m7g8-actions/node-setup@main
+      uses: p6m7g8-actions/p6-node-setup@main
     - name: Assume role using OIDC
-      uses: p6m7g8-actions/aws-credentials@main
+      uses: p6m7g8-actions/p6-aws-setup@main
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.aws_role }}


### PR DESCRIPTION
**What:** Updates `uses:` refs to the renamed action repositories.

**Why:** 35 action repos in `p6m7g8-actions` were renamed to a consistent four-tier prefix scheme (`gh-`, `p6-gh-`, `p6-`, `p6df-`) with noun-verb ordering and no agent nouns. GitHub redirects the old names, so the rename broke nothing and this is cleanup rather than a fix. Updating the refs makes the dependency graph readable without chasing redirects.

**Test plan:** Validated on `p6m7g8-actions/p6-repo-build#24` before this batch was opened. Its `build` job reached "Set up job: success", which is where composite action resolution happens, confirming the new names resolve. This PR's own `build` re-confirms it for this repo's specific refs.

**Dependencies:** none. Every PR in this batch is independent.
